### PR TITLE
Restoring and improving the UT for log-level endpoint

### DIFF
--- a/cf_debug_server_test.go
+++ b/cf_debug_server_test.go
@@ -1,12 +1,14 @@
 package cf_debug_server_test
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 
 	cf_debug_server "github.com/cloudfoundry-incubator/cf-debug-server"
 	"github.com/pivotal-golang/lager"
@@ -113,5 +115,50 @@ var _ = Describe("CF Debug Server", func() {
 				Ω(netErr.Op).Should(Equal("listen"))
 			})
 		})
+		Context("checking log-level endpoint", func() {
+			port := 21005
+
+			validForms := map[lager.LogLevel][]string{
+				lager.DEBUG: []string{"debug", "DEBUG", "d", strconv.Itoa(int(lager.DEBUG))},
+				lager.INFO:  []string{"info", "INFO", "i", strconv.Itoa(int(lager.INFO))},
+				lager.ERROR: []string{"error", "ERROR", "e", strconv.Itoa(int(lager.ERROR))},
+				lager.FATAL: []string{"fatal", "FATAL", "f", strconv.Itoa(int(lager.FATAL))},
+			}
+
+			//This will add another 16 unit tests to the suit
+			for level, acceptedForms := range validForms {
+				for _, form := range acceptedForms {
+					port++
+
+					testLevel := level
+					testForm := form
+					testPort := port
+
+					It("can reconfigure the given sink with "+form, func() {
+						address := fmt.Sprintf("127.0.0.1:%d", testPort)
+
+						err := cf_debug_server.Run(address, sink)
+						Expect(err).ToNot(HaveOccurred())
+
+						sink.Log(testLevel, []byte("hello before level change"))
+						Eventually(logBuf).ShouldNot(gbytes.Say("hello before level change"))
+
+						request, err := http.NewRequest("PUT", fmt.Sprintf("http://%s/log-level", address), bytes.NewBufferString(testForm))
+
+						Expect(err).ToNot(HaveOccurred())
+
+						response, err := http.DefaultClient.Do(request)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(response.StatusCode).To(Equal(http.StatusOK))
+						response.Body.Close()
+
+						sink.Log(testLevel, []byte("Logs sent with log-level "+testForm))
+						Eventually(logBuf).Should(gbytes.Say("Logs sent with log-level " + testForm))
+					})
+				}
+			}
+		})
+
 	})
 })


### PR DESCRIPTION
Restored the unit test cases for log-level endpoint.
Improved the assertion of the log messages for each acceptable forms.
This PR tries to resolve https://www.pivotaltracker.com/story/show/91912146